### PR TITLE
adding state_class attribute

### DIFF
--- a/speedtest/config.yaml
+++ b/speedtest/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Speedtest"
 description: "Speedtest-cli addon"
-version: 1.3.0
+version: 1.4.0
 slug: "speedtest_addon"
 init: false
 boot: manual

--- a/speedtest/rootfs/etc/services.d/speedtest/run
+++ b/speedtest/rootfs/etc/services.d/speedtest/run
@@ -18,7 +18,7 @@ function post_result() {
     local friendlyname=${3}
     local state=${4}
 
-    local data="{\"state\":$state, \"attributes\":{\"unit_of_measurement\":\"$unitmeasure\",\"friendly_name\":\"$friendlyname\",\"icon\":\"mdi:speedometer\"}}"
+    local data="{\"state\":$state, \"attributes\":{\"state_class\":\"measurement\",\"unit_of_measurement\":\"$unitmeasure\",\"friendly_name\":\"$friendlyname\",\"icon\":\"mdi:speedometer\"}}"
     
     bashio::api.supervisor POST "/core/api/states/sensor.speedtest_$sensor" "$data"
 


### PR DESCRIPTION
HA requires state_class attribute to be defined. I'm not sure if this will be enough and I could not tested it.
However I checked the attributes set by the original speedtest integration and there state_class is present.

Error in HA under dev tools -> statistics:
### Unsupported state class
The state class of this entity, is not supported. 
Statistics can not be generated until this entity has a supported state class.
If this state class was provided by an integration, this is a bug. Please report an issue.
If you have set this state class yourself, please correct it. The different state classes and when to use which can be found in the[ developer documentation](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics). If the state class has permanently changed, you may want to remove the long term statistics of it from your database.